### PR TITLE
Linting/Refactoring

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -50,7 +50,6 @@
         "no-nested-ternary": "error",
         "no-prototype-builtins": "error",
         "no-script-url": "error",
-        "no-undefined": "error",
         "no-underscore-dangle": ["error", {"allowAfterThis": true}],
         "no-useless-concat": "error",
         "no-var": "error",

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,5 +1,4 @@
-badiDate - Documentation
-============================
+# badiDate - Documentation
 
 ## Dependencies
 
@@ -52,16 +51,16 @@ The other dependencies are best included from a CDN, such as CDNJS:
 For bundling (e.g. with rollup) you can then import the ES6 module via
 
 ```js
-import {BadiDate, LocalBadiDate, badiDateOptions, MeeusSunMoon} from 'badidate'
+import {BadiDate, LocalBadiDate, badiDateOptions, MeeusSunMoon} from 'badidate';
 ```
 
 or directly use it in the browser via
 
 ```js
-import {BadiDate, LocalBadiDate, badiDateOptions, MeeusSunMoon} from 'node_modules/badidate/dist/localBadiDate-mss-locales-es.js'
+import {BadiDate, LocalBadiDate, badiDateOptions, MeeusSunMoon} from 'node_modules/badidate/dist/localBadiDate-mss-locales-es.js';
 ```
 
-where MeeusSunMoon is imported in order to be able to set the modules options via `MeeusSunMoon.options()` (see 
+where MeeusSunMoon is imported in order to be able to set the modules options via `MeeusSunMoon.options()` (see
 [MeeusSunMoon](https://github.com/janrg/MeeusSunMoon)).
 
 If the version of `localBadiDate*.js` without bundled  MeeusSunMoon is used, the module has to be loaded globally via its UMD bundle in order
@@ -75,7 +74,7 @@ There are two configuration options that can be set as
 badiDateOptions({
   useClockLocations: false, // default: true
   defaultLanguage: 'en', // default: 'en'
-})
+});
 ```
 
 (Note that two of the options for MeeusSunMoon, `roundToNearestMinute` and `returnTimeForPNMS`, default to `true` when using the badiDate module.)
@@ -89,8 +88,8 @@ badiDateOptions({
 The BadiDate object represents a Badí' date with some simplifications in order to make it independent of location
 (for local Badí' dates, a wrapper class, `LocalBadiDate()` exists, see below), namely
 
-* Badí' dates are taken to correspond to Gregorian dates 1-1, i.e. to start at midnight
-* No other times (e.g. for Holy Day commemorations) are stored
+*   Badí' dates are taken to correspond to Gregorian dates 1-1, i.e. to start at midnight
+*   No other times (e.g. for Holy Day commemorations) are stored
 
 For dates in 172 BE and after (21 March 2015 and after), the new implementation is used to calculate the beginning
 of the year, all Holy Days, and the length of Ayyám-i-Há, for earlier dates the earlier implementation, where for the
@@ -104,11 +103,11 @@ There are a number of different ways, in which a badiDate object can be created:
 #### From a moment or Date object
 
 ```js
-var myMoment = moment('2015-03-21');
-var myBadiDate1 = new BadiDate(myMoment);
-    
-var myDate = new Date('2015-03-21');
-var myBadiDate2 = new BadiDate(myDate);
+const myMoment = moment('2015-03-21');
+const myBadiDate1 = new BadiDate(myMoment);
+
+const myDate = new Date('2015-03-21');
+const myBadiDate2 = new BadiDate(myDate);
 ```
 
 Sets the Badí' date from the Gregorian date given by the moment or Date object. Any time or timezone information
@@ -117,7 +116,7 @@ is ignored.
 #### From an ISO 8601 string
 
 ```js
-var myBadiDate = new BadiDate('2015-03-21');
+const myBadiDate = new BadiDate('2015-03-21');
 ```
 
 Sets the Badí' date from the Gregorian date given by the string. Handling of malformed strings is attempted by
@@ -127,10 +126,10 @@ is ignored.
 #### From a Badí' date string or array
 
 ```js
-var myBadiDate1 = new BadiDate('172-1-1')
-var myBadiDate2 = new BadiDate('172-1');
-var myBadiDate3 = new BadiDate([172, 1, 1]);
-var myBadiDate4 = new BadiDate([172, 1]);
+const myBadiDate1 = new BadiDate('172-1-1');
+const myBadiDate2 = new BadiDate('172-1');
+const myBadiDate3 = new BadiDate([172, 1, 1]);
+const myBadiDate4 = new BadiDate([172, 1]);
 ```
 
 Sets the Badí' date from the given string or array. Arguments can either be in the format `'Y-M-D'`,
@@ -156,7 +155,7 @@ the latter of which is included in some of the bundles.
 A local Badí' date object is created with
 
 ```js
-var date1 = new LocalBadiDate(date, latitude, longitude, timezoneId)
+const date1 = new LocalBadiDate(date, latitude, longitude, timezoneId);
 ```
 
 where `date` accepts the same input formats as `BadiDate()`, `latitude` and `longitude` are the geographic latitude and longitude
@@ -300,7 +299,7 @@ BadiDate.format(formatString, language)
 
 Outputs the date in the format as given by formatString and in the given language. The following tokens are replaced in `formatString`:
 
-|                   | Token | Output 
+|                   | Token | Output
 |-------------------|-------|--------
 | **Day**           | d     | Day of the month, without leading zeroes
 |                   | dd    | Day of the month, with leading zeroes
@@ -332,7 +331,7 @@ Outputs the date in the format as given by formatString and in the given languag
 If no formatting string is given, `format()` defaults to `'d MM+ y BE'`. E.g.
 
 ```js
-var myBadiDate = new BadiDate([172, 1, 1]);
+const myBadiDate = new BadiDate([172, 1, 1]);
 console.log(myBadiDate.format());
 ```
 
@@ -356,15 +355,14 @@ roughly to reduce vertex count and no attempt was made to capture to boundary to
 
 The groups of three times given below correspond to sunrise, solar noon, and sunset.
 
-* **Canada**: 06:30, 12:00, 18:00 above 60°N latitude.
-* **Finland**: 06:00, 12:00, 18:00 local standard time (i.e. 07:00, 13:00, 19:00 in local time when DST is in effect), **except** for the
-month of `Alá´, where the actual times for sunrise, solar noon, and sunset are used.
-* **Iceland**: 06:00, 13:00, 18:00.
-* **Norway**: 06:00, 12:00, 18:00.
-* **Sweden**: 06:00, 12:00, 18:00 in Norrland (i.e. Lapland, Norrbotten, Västerbotten, Jämtland, Ångermanland, Medelpad, Härjedalen,
+*   **Canada**: 06:30, 12:00, 18:00 above 60°N latitude.
+*   **Finland**: 06:00, 12:00, 18:00 local standard time (i.e. 07:00, 13:00, 19:00 in local time when DST is in effect), **except** for the
+month of \`Alá´, where the actual times for sunrise, solar noon, and sunset are used.
+*   **Iceland**: 06:00, 13:00, 18:00.
+*   **Norway**: 06:00, 12:00, 18:00.
+*   **Sweden**: 06:00, 12:00, 18:00 in Norrland (i.e. Lapland, Norrbotten, Västerbotten, Jämtland, Ångermanland, Medelpad, Härjedalen,
 Hälsingland, and Gästriksland)
-* **USA**: 06:00, 12:00, 18:00 local standard time (i.e. 07:00, 13:00, 19:00 in local time when DST is in effect) **in Alaska**.
-
+*   **USA**: 06:00, 12:00, 18:00 local standard time (i.e. 07:00, 13:00, 19:00 in local time when DST is in effect) **in Alaska**.
 
 ## The Source Data
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Badí' Date
-============
+# Badí' Date
 
 [![MIT License][license-image]][license-url]
 

--- a/res/generateYears.js
+++ b/res/generateYears.js
@@ -80,23 +80,23 @@ const badiMonthDayTB = function (gregDate, nawRuzTihran) {
  * Generate the long and short list of dates for use in the badiDate class
  */
 const yearList = function () {
-  let ayyamiHaLength, nawRuzTihran, nextNawRuzTihran, TB;
   let longList = 'const badiYears = {\n';
   let shortList = 'const badiYears = [\n  ';
   // Stop at end of 2350 AD / 507 BE as the Naw-Rúz 509 BE is potentially too
   // close to call
   const equinoxesLength = 337;
   for (let i = 0; i < equinoxesLength - 1; i++) {
-    nawRuzTihran = nawRuzTihranUTC(equinoxes[i]);
-    nextNawRuzTihran = nawRuzTihranUTC(equinoxes[i + 1]);
-    ayyamiHaLength = Math.round(nextNawRuzTihran.diff(
+    const nawRuzTihran = nawRuzTihranUTC(equinoxes[i]);
+    const nextNawRuzTihran = nawRuzTihranUTC(equinoxes[i + 1]);
+    const ayyamiHaLength = Math.round(nextNawRuzTihran.diff(
       nawRuzTihran, 'day', true) - 361);
-    TB = twinBirthdays(nawRuzTihran);
-    longList += '  ' + (i + 172).toString() + ': {\n' +
-            '    aHL: ' + ayyamiHaLength + ',\n' +
-            '    NR: \'' + nawRuzTihran.format('YYYY-MM-DD') + '\',\n' +
-            '    TB: [' + TB[0] + ', ' + TB[1] + ', ' + TB[2] + ', ' + TB[3] +
-            ']\n  }';
+    const TB = twinBirthdays(nawRuzTihran);
+    longList += `  ${(i + 172).toString()}: {
+    aHL: ${ayyamiHaLength},
+    NR: '${nawRuzTihran.format('YYYY-MM-DD')}',
+    TB: [${TB[0]}, ${TB[1]}, ${TB[2]}, ${TB[3]}
+]
+  }`;
     shortList += '\'' + nawRuzTihran.date().toString(36) +
       ayyamiHaLength.toString(36) + TB[0].toString(36) +
       TB[1].toString(36) + '\'';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,13 +20,12 @@ function localeRegex(languageCodes) {
     'zh', 'en_us', 'en-us'];
   let localeListString = '';
   for (let i = 0; i < locales.length; i++) {
-    if (languageCodes.indexOf(locales[i]) === -1) {
+    if (!languageCodes.includes(locales[i])) {
       localeListString += '|' + locales[i];
     }
   }
   localeListString = localeListString.slice(1);
-  let regexString = '';
-  regexString = '(import \\* as (' + localeListString +
+  const regexString = '(import \\* as (' + localeListString +
       ") from '\\.\\/locale\\/(" + localeListString +
       ")\\.js';|badiLocale\\['(" + localeListString +
       ")'] = (" + localeListString + ');)';

--- a/src/badiDate.js
+++ b/src/badiDate.js
@@ -89,7 +89,8 @@ class BadiDate {
    * @param {string} language output language (subject to fallbacks)
    * @returns {string} date formatted according to inputs
    */
-  format(formatString, language) { // eslint-disable-line complexity
+  format(formatString = 'd MM+ y BE', // eslint-disable-line complexity
+    language) {
     if (!this.isValid()) {
       return 'Not a valid date';
     }
@@ -97,7 +98,7 @@ class BadiDate {
       ['DDL', 'DD+', 'MML', 'MM+', 'WWL', 'yyv'],
       ['dd', 'DD', 'mm', 'MM', 'ww', 'WW', 'yv', 'YV', 'vv', 'kk', 'yy', 'BE'],
       ['d', 'D', 'm', 'M', 'W', 'v', 'k', 'y']];
-    if (typeof language === 'undefined' ||
+    if (language === undefined ||
         typeof badiLocale[language] === 'undefined') {
       // eslint-disable-next-line dot-notation
       if (typeof badiLocale['default'] === 'undefined') {
@@ -106,9 +107,7 @@ class BadiDate {
         language = 'default';
       }
     }
-    if (typeof formatString === 'undefined') {
-      formatString = 'd MM+ y BE';
-    } else if (typeof formatString !== 'string') {
+    if (typeof formatString !== 'string') {
       return 'Invalid formatting string.';
     }
     let returnString = '';
@@ -116,30 +115,30 @@ class BadiDate {
     for (let i = 0; i < length; i++) {
       // Text wrapped in {} is output as-is. A '{' without a matching '}'
       // results in invalid input
-      if (formatString.charAt(i) === '{' && i < length - 1) {
+      if (formatString[i] === '{' && i < length - 1) {
         for (let j = i + 1; j <= length; j++) {
           if (j === length) {
             return 'Invalid formatting string.';
           }
-          if (formatString.charAt(j) === '}') {
+          if (formatString[j] === '}') {
             i = j;
             break;
           }
-          returnString += formatString.charAt(j);
+          returnString += formatString[j];
         }
       } else {
-        const next1 = formatString.charAt(i);
-        const next2 = next1 + formatString.charAt(i + 1);
-        const next3 = next2 + formatString.charAt(i + 2);
+        const next1 = formatString[i];
+        const next2 = next1 + formatString[i + 1];
+        const next3 = next2 + formatString[i + 2];
         // First check for match to 3-symbol token, then 2, then 1
         // (Tokens are not uniquely decodable)
-        if (formatTokens[0].indexOf(next3) > -1) {
+        if (formatTokens[0].includes(next3)) {
           returnString += this._getFormatItem(next3, language);
           i += 2;
-        } else if (formatTokens[1].indexOf(next2) > -1) {
+        } else if (formatTokens[1].includes(next2)) {
           returnString += this._getFormatItem(next2, language);
           i += 1;
-        } else if (formatTokens[2].indexOf(next1) > -1) {
+        } else if (formatTokens[2].includes(next1)) {
           returnString += this._getFormatItem(next1, language);
         } else {
           returnString += next1;
@@ -156,24 +155,22 @@ class BadiDate {
    * @returns {string} localized output string in desired language (or fallback)
    */
   _getFormatItem(token, language) { // eslint-disable-line complexity
-    // ES6 is a bit funny with the scope of let in a switch
-    let day, month, monthL;
     switch (token) {
       // Single character tokens
       case 'd':
         return String(this._badiDay);
-      case 'D':
-        day = this._formatItemFallback(language, 'month', this._badiDay);
+      case 'D': {
+        const day = this._formatItemFallback(language, 'month', this._badiDay);
         if (day.substring(4, 5) === '’' && day.substring(0, 1) === '‘') {
           return day.substring(0, 5);
         } else if (day.substring(0, 1) === '‘') {
           return day.replace(/<(?:.|\n)*?>/gm, '').substring(0, 4);
         }
         return day.replace(/<(?:.|\n)*?>/gm, '').substring(0, 3);
-      case 'm':
+      } case 'm':
         return String(this._badiMonth);
-      case 'M':
-        month = this._formatItemFallback(
+      case 'M': {
+        const month = this._formatItemFallback(
           language, 'month', this._badiMonth);
         if (month.substring(4, 5) === '’' && month.substring(0, 1) === '‘') {
           return month.substring(0, 5);
@@ -181,7 +178,7 @@ class BadiDate {
           return month.replace(/<(?:.|\n)*?>/gm, '').substring(0, 4);
         }
         return month.replace(/<(?:.|\n)*?>/gm, '').substring(0, 3);
-      case 'W':
+      } case 'W':
         return this._formatItemFallback(
           language, 'weekdayAbbbr3', (this._gregDate.isoWeekday() + 1) % 7 + 1);
       case 'y':
@@ -229,16 +226,16 @@ class BadiDate {
           ')';
       case 'MML':
         return this._formatItemFallback(language, 'monthL', this._badiMonth);
-      case 'MM+':
-        month = this._formatItemFallback(
+      case 'MM+': {
+        const month = this._formatItemFallback(
           language, 'month', this._badiMonth);
-        monthL = this._formatItemFallback(
+        const monthL = this._formatItemFallback(
           language, 'monthL', this._badiMonth);
         if (month === monthL) {
           return month;
         }
         return month + ' (' + monthL + ')';
-      case 'WWL':
+      } case 'WWL':
         return this._formatItemFallback(
           language, 'weekdayL', (this._gregDate.isoWeekday() + 1) % 7 + 1);
       case 'yyv':
@@ -255,7 +252,7 @@ class BadiDate {
    * @returns {string} next item in fallback order
    */
   _languageFallback(languageCode) {
-    if (languageCode.indexOf('-') > -1) {
+    if (languageCode.includes('-')) {
       return languageCode.split('-')[0];
     // eslint-disable-next-line no-negated-condition
     } else if (languageCode !== 'default') {
@@ -273,7 +270,7 @@ class BadiDate {
    * @returns {string} localized output string
    */
   _formatItemFallback(language, category, index) {
-    if (typeof index === 'undefined') {
+    if (index === undefined) {
       while (typeof badiLocale[language] === 'undefined' ||
              typeof badiLocale[language][category] === 'undefined') {
         language = this._languageFallback(language);
@@ -332,11 +329,8 @@ class BadiDate {
    * @returns {bool} whether the provided datetime is within the valid range
    */
   _notInValidGregRange(datetime) {
-    if (datetime.isBefore(moment.utc('1844-03-21')) ||
-        datetime.isAfter(moment.utc('2351-03-20'))) {
-      return true;
-    }
-    return false;
+    return datetime.isBefore(moment.utc('1844-03-21')) ||
+        datetime.isAfter(moment.utc('2351-03-20'));
   }
 
   /**


### PR DESCRIPTION
- Linting: Remove `no-undefined` rule (see first item below)
- Refactoring:
    1. Utilize `undefined` where wouldn't cause error or warning (in modules, strict mode is automatically enforced, so redefining of `undefined` not possible)
    2. `includes` over `indexOf`
    3. `const` over `let` (including within `switch` by adding curly brackets around `case`)
    4. Template in place of long concatenated string
    5. Leverage default parameters (which, as per current behavior, default only for `undefined`)
    6. String indexes over `charAt`
    7. Just return result of boolean functions rather than indicating booleans manually
- Markdown linting:
    1. Use consistent heading style
    2. Use consistent semi-colon usage except in signatures
    3. Remove trailing whitespace
    4. Use `const` in examples
    4. Use three spaces at beginning of list items (to follow default Markdown linter rules and get Atom linter to stop complaining)