### PR TITLE
- Testing: Collect coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    collectCoverage: false,
+    collectCoverage: true,
     coverageDirectory: 'coverage',
     preset: 'ts-jest',
     testEnvironment: 'node',


### PR DESCRIPTION
Though I figured you may have some reason for not setting coverage, I thought I'd offer the PR in case you wanted the change.

As I see it, coverage is kind of "out of sight, out of mind", so if it's not on, especially if no `nyc` threshholds are set in `package.json` to enforce an expected coverage percent, it may never get addressed.

Thanks!